### PR TITLE
openrefine disppeared again!

### DIFF
--- a/_includes/swc/setup.html
+++ b/_includes/swc/setup.html
@@ -4,10 +4,10 @@
 {% endunless %}
 
 {% include install_instructions/spreadsheets.html %}
+{% include install_instructions/openrefine.html %}
 {% include install_instructions/sql.html %}
 {% include install_instructions/shell.html %}
 {% include install_instructions/git.html %}
-
 
 {% include install_instructions/editor.html %}
 


### PR DESCRIPTION
I think when we removed lc installs earlier, we forgot to explicitly include the openrefine setup in the setup/swc and I just noticed. So its back now.  Sorry for not noticing earlier. 